### PR TITLE
Issue 151: Dockerize frontend for development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "map_dashboard",
+  "dockerComposeFile": [
+    "../.docker/docker-compose.yml"
+  ],
+  "service": "map_dashboard",
+  "workspaceFolder": "/app",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "eamodio.gitlens"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  },
+  "postCreateCommand": "npm install"
+}

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,28 @@
+# Step 1: Choose a Base Image
+# Using Node.js 20 on Alpine Linux for a lightweight container
+FROM node:20-alpine
+
+# Step 2: Set Working Directory
+# Allow the workdir to be overridden at build time, default is /app
+ARG WORKDIR=/app
+WORKDIR ${WORKDIR}
+
+# Optional: helpful tooling
+RUN apk add --no-cache bash
+
+# Step 3: Copy Application Files (for dependency caching)
+# Copy only package manifests first
+COPY package.json package-lock.json ${WORKDIR}/
+
+# Step 4: Install Dependencies
+RUN npm ci
+
+# Step 5: Copy the Rest of the Source Code
+# Copy everything else into /app
+COPY . ${WORKDIR}/
+
+# Step 6: Define the Command to Run the App
+# Expose Vite's default dev server port
+EXPOSE 5173
+# Run the Vite dev server in shell form so it listens on all interfaces
+CMD npm run dev -- --host 0.0.0.0 --port 5173

--- a/.docker/docker-compose.ci.test.yml
+++ b/.docker/docker-compose.ci.test.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+
+services:
+  map_dashboard:
+    container_name: "map_dashboard_ci"
+    build:
+      context: ../
+      dockerfile: .docker/Dockerfile
+    volumes:
+      - type: bind
+        source: "../"
+        target: "/app"
+      - /app/node_modules
+    command: ["sh", "-c", "npm ci && npm test"]
+    networks:
+      - dashboard_dev
+
+networks:
+  dashboard_dev:
+    external: true

--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+
+services:
+  map_dashboard:
+    container_name: "map_dashboard"
+    build:
+      context: ../
+      dockerfile: .docker/Dockerfile
+    ports:
+      - "5173:5173"
+    volumes:
+      - type: bind
+        source: "../"
+        target: "/app"
+      - /app/node_modules
+    command: npm run dev -- --host 0.0.0.0 --port 5173
+    networks:
+      - dashboard_dev
+
+networks:
+  dashboard_dev:
+    external: true


### PR DESCRIPTION
## Description

Created four files to dockerize frontend:
* .devcontainer/devcontainer.json
* .docker/Dockerfile
* .docker/docker-compose.yml
* docker/docker-compose.ci.test.yml

## Type of Change

- [ ] Bug fix
- [✔️] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## How Has This Been Tested?

The frontend container runs successfully on `docker-compose.yml`, but requires the `dashboard_dev` network to be first created manually. You will see a warning; this is intentional. It arises from the `external: true` setting used in the compose file, which allows the frontend and backend to share the same network.

### 1. Create network first
docker network create dashboard_dev

### 2. Start container in detached mode
docker compose -f .docker/docker-compose.yml up -d

### 3. Enter interactive shell
docker compose -f .docker/docker-compose.yml exec map_dashboard bash

### 4. Exit shell
exit   # or Ctrl+D

### 5. Stop and remove container
docker compose -f .docker/docker-compose.yml down

## Checklist:

- [ ] My code follows the style guidelines of this project
- [✔️] I have performed a self-review of my code
- [✔️] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation (if applicable)

## Related Issues

Related to issue #152 